### PR TITLE
Make explicit demo is only available to UK Gov Orgs.

### DIFF
--- a/docs/address-lookup/v2/address-lookup-api.md
+++ b/docs/address-lookup/v2/address-lookup-api.md
@@ -1,14 +1,7 @@
 Address Lookup Microservice API (v2)
 ====================================
 
-## API Demo Environment - [UK Government Organisations](https://www.gov.uk/government/organisations) ##
-
-A demo of the Address Lookup Microservice is available to UK Government Organisations only. If you'd like to **test** the API, you will need to acquire a username and password and use basic auth with your http clients for all requests to the service.
-
-The base URL for the public demo is:
-https://txm-al-demo.tax.service.gov.uk/
-
-In order to gain access/test the API, please email David Crebbin [david.crebbin@digital.hmrc.gov.uk](mailto:david.crebbin@digital.hmrc.gov.uk), providing a breif introduction as to your reason for interest and which Government Organisation you represent.
+If you're a UK Government Organisation wanting additional information on this service, please email David Crebbin [david.crebbin@digital.hmrc.gov.uk](mailto:david.crebbin@digital.hmrc.gov.uk).
 
 ## What's Changed in v2
 

--- a/docs/address-lookup/v2/address-lookup-api.md
+++ b/docs/address-lookup/v2/address-lookup-api.md
@@ -1,18 +1,14 @@
 Address Lookup Microservice API (v2)
 ====================================
 
-## AWS Hosted Demo Environment ##
+## API Demo Environment - [UK Government Organisations](https://www.gov.uk/government/organisations) ##
 
-A demo of the Address Lookup Microservice has been deployed on AWS and
-is publicly available. If you want to kick the tyres on the demo you
-will need to acquire a username and password and use basic auth with
-your http clients for all requests to the service.
+A demo of the Address Lookup Microservice is available to UK Government Organisations only. If you'd like to **test** the API, you will need to acquire a username and password and use basic auth with your http clients for all requests to the service.
 
 The base URL for the public demo is:
 https://txm-al-demo.tax.service.gov.uk/
 
-Please email David Crebbin [david.crebbin@digital.hmrc.gov.uk](mailto:david.crebbin@digital.hmrc.gov.uk)
-for a username password to test the service.
+In order to gain access/test the API, please email David Crebbin [david.crebbin@digital.hmrc.gov.uk](mailto:david.crebbin@digital.hmrc.gov.uk), providing a breif introduction as to your reason for interest and which Government Organisation you represent.
 
 ## What's Changed in v2
 


### PR DESCRIPTION
1) I don't think we need to explicitly state where this is hosted (AWS).
2) Not sure we need to give a reason as to why the demo environment is only available to UK Government Orgs?

Thoughts